### PR TITLE
Add extra fields to MemberPage class

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -17,6 +17,10 @@ class MemberPage < Scraped::HTML
     noko.css('.deputat-info-left img/@src').text
   end
 
+  field :source do
+    url.to_s
+  end
+
   field :birth_date do
     date_from(noko.css('p.deputat-info-date').text)
   end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -29,6 +29,10 @@ class MemberPage < Scraped::HTML
     date_from(noko.xpath('//p[contains(.,"Дата начала полномочий")]').text)
   end
 
+  field :end_date do
+    date_from(noko.xpath('//p[contains(.,"Дата окончания полномочий")]').text)
+  end
+
   field :area_id do
     area_id_from(noko.xpath('//p[contains(.,"избирательного округа")]').text)
   end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -7,6 +7,10 @@ class MemberPage < Scraped::HTML
     Pathname.new(url.to_s).basename.to_s
   end
 
+  field :name do
+    noko.at_css('.hc-r h1').text
+  end
+
   field :birth_date do
     date_from(noko.css('p.deputat-info-date').text)
   end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -3,12 +3,18 @@
 require 'scraped'
 
 class MemberPage < Scraped::HTML
+  decorator Scraped::Response::Decorator::AbsoluteUrls
+
   field :id do
     Pathname.new(url.to_s).basename.to_s
   end
 
   field :name do
     noko.at_css('.hc-r h1').text
+  end
+
+  field :image do
+    noko.css('.deputat-info-left img/@src').text
   end
 
   field :birth_date do


### PR DESCRIPTION
When a membership ends the member is no longer listed on the index page, but they still have individual member pages. This change adds some extra fields to the `MemberPage` class so that when we scrape it directly we still have the information we want.

I'll do a separate pull request after this one to actually scrape the pages of ceased members.