### PR TITLE
Scrape ceased memberships

### DIFF
--- a/lib/all_members_page.rb
+++ b/lib/all_members_page.rb
@@ -16,4 +16,8 @@ class AllMembersPage < Scraped::HTML
       }
     end
   end
+
+  field :member_urls do
+    noko.xpath('id("lists_list_elements_35")//tr[td]//td[1]//a/@href').map(&:text)
+  end
 end

--- a/lib/all_members_page.rb
+++ b/lib/all_members_page.rb
@@ -4,19 +4,6 @@ require 'scraped'
 class AllMembersPage < Scraped::HTML
   decorator Scraped::Response::Decorator::AbsoluteUrls
 
-  field :members do
-    noko.xpath('id("lists_list_elements_35")//tr[td]').map do |tr|
-      tds = tr.css('td')
-      {
-        name:    tds[1].text.tidy,
-        faction: tds[2].text.sub('Фракция ', '').tidy,
-        area:    tds[4].text.tidy,
-        image:   tds[0].css('img/@src').text,
-        source:  tds[1].css('a/@href').text,
-      }
-    end
-  end
-
   field :member_urls do
     noko.xpath('id("lists_list_elements_35")//tr[td]//td[1]//a/@href').map(&:text)
   end

--- a/scraper.rb
+++ b/scraper.rb
@@ -19,12 +19,11 @@ def scrape(h)
 end
 
 url = 'http://www.duma.gov.ru/structure/deputies/?letter=%D0%92%D1%81%D0%B5'
-page = scrape(url => AllMembersPage)
-warn "Found #{page.members.count} members"
+member_urls = scrape(url => AllMembersPage).member_urls
+warn "Found #{member_urls.count} members"
 
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
-page.members.each do |mem|
-  data = mem.merge scrape(mem[:source] => MemberPage).to_h
-  # puts data
+member_urls.each do |mem_url|
+  data = scrape(mem_url => MemberPage).to_h
   ScraperWiki.save_sqlite(%i(id), data)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -18,8 +18,12 @@ def scrape(h)
   klass.new(response: Scraped::Request.new(url: url).response)
 end
 
+CEASED_MEMBER_IDS = %w(1756605 1756928 1757002).freeze
+ceased_member_urls = CEASED_MEMBER_IDS.map { |id| "http://www.duma.gov.ru/structure/deputies/#{id}/" }
+
 url = 'http://www.duma.gov.ru/structure/deputies/?letter=%D0%92%D1%81%D0%B5'
-member_urls = scrape(url => AllMembersPage).member_urls
+current_member_urls = scrape(url => AllMembersPage).member_urls
+member_urls = current_member_urls + ceased_member_urls
 warn "Found #{member_urls.count} members"
 
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil


### PR DESCRIPTION
These members are no longer listed on the index page because their
memberships have ended. However, we still want to scrape their individual
pages.

Ideally, we'd find a way to do this without having to hard-code the
member ids like this. But for now, this gets the job done.

# Notes to merger

Please do the following before merging:

- [x] Change the base branch to `master` once https://github.com/everypolitician-scrapers/russia-duma-2016/pull/2 has been merged.
- [x] Change the base branch to `master` once #5 has been merged.