### PR TITLE
Tidy up name string in MemberPage class

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -10,7 +10,7 @@ class MemberPage < Scraped::HTML
   end
 
   field :name do
-    noko.at_css('.hc-r h1').text
+    noko.at_css('.hc-r h1').text.tidy
   end
 
   field :image do


### PR DESCRIPTION
We were getting extra whitespace on a few pages, so call `String#tidy` which Scraped provides to clean the `name` field up.