### PR TITLE
Add faction and area to MemberPage

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -25,6 +25,10 @@ class MemberPage < Scraped::HTML
     noko.xpath('.//div[@class = "deputat-info-right"]/ul[@class = "list-ul1"][1]//a[1]/@title').text.tidy
   end
 
+  field :area do
+    noko.xpath('.//div[@class = "deputat-info-right"]/ul[@class = "list-ul1"][2]/li').text.tidy
+  end
+
   field :birth_date do
     date_from(noko.css('p.deputat-info-date').text)
   end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -21,6 +21,10 @@ class MemberPage < Scraped::HTML
     url.to_s
   end
 
+  field :faction do
+    noko.xpath('.//div[@class = "deputat-info-right"]/ul[@class = "list-ul1"][1]//a[1]/@title').text.tidy
+  end
+
   field :birth_date do
     date_from(noko.css('p.deputat-info-date').text)
   end


### PR DESCRIPTION
We're currently getting faction and area information from the page with a list of all members, but that list doesn't include ceased members, and the information is available on the individual member pages, so we might as well grab it from there.

Note that we're not yet handling ceased members, that's happening in https://github.com/everypolitician-scrapers/russia-duma-2016/pull/3, but when we do we'll want to get their `faction` and `area` fields as well, so this helps with that.