### PR TITLE
Remove faction prefix

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -22,7 +22,10 @@ class MemberPage < Scraped::HTML
   end
 
   field :faction do
-    noko.xpath('.//div[@class = "deputat-info-right"]/ul[@class = "list-ul1"][1]//a[1]/@title').text.tidy
+    noko.xpath('.//div[@class = "deputat-info-right"]/ul[@class = "list-ul1"][1]//a[1]/@title')
+        .text
+        .delete('Фракция ')
+        .tidy
   end
 
   field :area do

--- a/test/data/1756684.yml
+++ b/test/data/1756684.yml
@@ -6,7 +6,7 @@
   :name: Абрамов Иван Николаевич
   :image: http://www.duma.gov.ru/upload/iblock/82a/82a15e0814398c3ee8544e740bc64bf7.jpg
   :source: http://www.duma.gov.ru/structure/deputies/1756684/
-  :faction: Фракция ЛДПР
+  :faction: ЛДПР
   :area: Амурская область
   :birth_date: '1978-06-16'
   :start_date: '2016-09-18'


### PR DESCRIPTION
Factions have started coming in with a 'Фракция' prefix; we don't want
to capture that.

The test cassette was added after that started, so is up to date, but
the test data added at that point doesn't reflect what we want.